### PR TITLE
Bump native SDKs to iOS 3.34.0 / Android 3.33.0 + fix trackOnce never completing on iOS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 31
         versionCode 1
-        versionName '3.24.0-beta.3'
+        versionName '3.34.0'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -48,7 +48,7 @@ android {
 }
 
 dependencies {
-    implementation 'io.radar:sdk:3.24.1'
+    implementation 'io.radar:sdk:3.33.0'
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/ios/Classes/RadarFlutterPlugin.m
+++ b/ios/Classes/RadarFlutterPlugin.m
@@ -310,9 +310,9 @@
 
 - (void)trackOnce:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     RadarTrackCompletionHandler completionHandler = ^(RadarStatus status, CLLocation *location, NSArray<RadarEvent *> *events, RadarUser *user) {
+        NSMutableDictionary *dict = [NSMutableDictionary new];
+        [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
         if (status == RadarStatusSuccess) {
-            NSMutableDictionary *dict = [NSMutableDictionary new];
-            [dict setObject:[Radar stringForStatus:status] forKey:@"status"];
             if (location) {
                 [dict setObject:[Radar dictionaryForLocation:location] forKey:@"location"];
             }
@@ -323,8 +323,8 @@
                 [dict setObject:[user dictionaryValue] forKey:@"user"];
             }
             [dict setObject: [RadarState lastMotionActivityData][@"type"] ?: @"unknown" forKey:@"motionActivity"];
-            result(dict);
         }
+        result(dict);
     };
 
     NSDictionary *argsDict = call.arguments;

--- a/ios/flutter_radar.podspec
+++ b/ios/flutter_radar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_radar'
-  s.version          = '3.24.0-beta.3'
+  s.version          = '3.34.0'
   s.summary          = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.description      = 'Flutter package for Radar, the leading geofencing and location tracking platform'
   s.homepage         = 'http://example.com'
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'RadarSDK', '3.24.1'
-  s.ios.deployment_target = '12.0'
+  s.dependency 'RadarSDK', '>= 3.24.0'
+  s.ios.deployment_target = '13.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_radar
 description: Flutter package for Radar, the leading geofencing and location tracking platform
-version: 3.24.0-beta.3
+version: 3.34.0
 homepage: https://github.com/radarlabs/flutter-radar
 
 environment:


### PR DESCRIPTION
## Summary

Bumps the native SDK versions and fixes a bug where iOS `trackOnce` never completes the Dart future on failure (radarlabs/flutter-radar#88).

## Changes

### Native SDK bumps
- iOS RadarSDK: 3.24.1 → 3.34.0 (includes Swift rewrite of `RadarFileStorage` and `RadarLogBuffer`)
- Android Radar SDK: 3.24.1 → 3.33.0
- iOS deployment target: 12.0 → 13.0 (required by RadarSDK 3.34.0)
- Relaxed podspec RadarSDK constraint from `~> 3.24.0` to `>= 3.24.0`

### iOS `trackOnce` fix (RadarFlutterPlugin.m)
Previously the iOS plugin only called `result()` on `RadarStatusSuccess`, causing the Dart future to hang forever on any failure. Now it always returns a response with the status field, matching Android behavior. This addresses [radarlabs/flutter-radar#88](https://github.com/radarlabs/flutter-radar/issues/88).

### Why this matters

The native SDK 3.24.x `RadarFileStorage` and `RadarLogBuffer` use synchronous file I/O on the main thread via `NSFileCoordinator` semaphore waits. This causes 2+ second app hangs on iOS. The 3.34.0 Swift rewrite uses dedicated background dispatch queues and actor isolation, eliminating the main-thread blocking.

### Note on iOS SDK distribution

iOS RadarSDK 3.34.0 is not published to CocoaPods (Radar has deprecated CocoaPods in favor of SPM). Apps using this fork will need to add the following to their Podfile to pull RadarSDK from source:

```ruby
pod 'RadarSDK', :git => 'https://github.com/radarlabs/radar-sdk-ios.git', :tag => '3.34.0'
```

## Tested on
- iOS 18.x
- Android 14+

## Related
- Closes radarlabs/flutter-radar#88 (if merged upstream)